### PR TITLE
fix: soon to be broken link

### DIFF
--- a/README.org
+++ b/README.org
@@ -11,7 +11,7 @@ search and open Firefox bookmarks and history. It can be downloaded
 
 =telescope-firefox.nvim= is an extension, so you need =telescope.nvim= to make it work.
 
-The package also needs [[https://github.com/tami5/sqlite.lua][sqlite.lua]] to be able to access the database
+The package also needs [[https://github.com/kkharji/sqlite.lua][sqlite.lua]] to be able to access the database
 containing bookmarks and history.
 
 
@@ -21,7 +21,7 @@ Install using [[https://github.com/junegunn/vim-plug][Plug]].
 
 #+BEGIN_SRC vim
 Plug 'nvim-telescope/telescope.nvim'
-Plug 'tami5/sqlite.lua'
+Plug 'kkharji/sqlite.lua'
 Plug 'dawsers/telescope-firefox.nvim'
 #+END_SRC
 

--- a/lua/telescope/_extensions/firefox/firefox.lua
+++ b/lua/telescope/_extensions/firefox/firefox.lua
@@ -1,6 +1,6 @@
 local ok, sqlite = pcall(require, "sqlite.db")
 if not ok then
-  error "Firefox depends on sqlite.lua (https://github.com/tami5/sqlite.lua)"
+  error "Firefox depends on sqlite.lua (https://github.com/kkharji/sqlite.lua)"
 end
 
 local pickers = require("telescope.pickers")


### PR DESCRIPTION
Hello @dawsers,

I recently changed my Github handle and realized I must keep existing references up to date, in order to prevent breaking your setup or, worse, exposing you to a security risk as a result of someone taking over my old handle and creating a repo with the same name.

Now, sqlite.lua link is updated.

